### PR TITLE
Add test for passing choice array variable.

### DIFF
--- a/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
+++ b/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
@@ -68,6 +68,6 @@ class FormTypeChoicesTest extends BasePHPVisitorTest
 
         $this->assertCount(1, $collection, print_r($collection, true));
         $this->assertEquals('label1', $collection->get(0)->getMessage());
-        $this->assertEquals(10, $collection->get(0)->getLine());
+        $this->assertEquals(9, $collection->get(0)->getLine());
     }
 }

--- a/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
+++ b/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
@@ -61,4 +61,13 @@ class FormTypeChoicesTest extends BasePHPVisitorTest
         $errors = $collection->getErrors();
         $this->assertCount(1, $errors);
     }
+
+    public function testPassedChoices()
+    {
+        $collection = $this->getSourceLocations(new FormTypeChoices(), Resources\Php\Symfony\SimpleChoicePassArrayType::class);
+
+        $this->assertCount(1, $collection, print_r($collection, true));
+        $this->assertEquals('label1', $collection->get(0)->getMessage());
+        $this->assertEquals(10, $collection->get(0)->getLine());
+    }
 }

--- a/tests/Resources/Php/Symfony/SimpleChoicePassArrayType.php
+++ b/tests/Resources/Php/Symfony/SimpleChoicePassArrayType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Translation\Extractor\Tests\Resources\Php\Symfony;
+
+class SimpleChoicePassArrayType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $validOptions = [
+            'label1' => 'key'
+        ];
+
+        $builder->add('test', null, [
+            'choices' => $validOptions,
+        ]);
+    }
+}


### PR DESCRIPTION
At the moment there is an error when passing array variable to a choices option in a symfony forms. I added only test case since I don't have too much time to go deeper into a code.