### PR TITLE
Support for `phtml` extension as PHP files

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -69,6 +69,7 @@ final class Extractor
         switch ($ext) {
             case 'php':
             case 'php5':
+            case 'phtml':
                 return 'php';
             case 'twig':
                 return 'twig';


### PR DESCRIPTION
`phtml` is an extension used commonly in Zend Framework ecosystem to name (partial) views.