### PR TITLE
Support for array_* callback in SourceLocation::createHere

### DIFF
--- a/src/Model/SourceLocation.php
+++ b/src/Model/SourceLocation.php
@@ -62,9 +62,13 @@ final class SourceLocation
      */
     public static function createHere($message, array $context = [])
     {
-        $trace = debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 1);
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2) as $trace) {
+            if (isset($trace['file'])) {
+                break;
+            }
+        }
 
-        return new self($message, $trace[0]['file'], $trace[0]['line'], $context);
+        return new self($message, $trace['file'], $trace['line'], $context);
     }
 
     /**

--- a/src/Model/SourceLocation.php
+++ b/src/Model/SourceLocation.php
@@ -63,6 +63,7 @@ final class SourceLocation
     public static function createHere($message, array $context = [])
     {
         foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 2) as $trace) {
+            // File is not set if we call from an anonymous context like an array_map function.
             if (isset($trace['file'])) {
                 break;
             }

--- a/tests/Unit/Model/SourceLocationTest.php
+++ b/tests/Unit/Model/SourceLocationTest.php
@@ -26,4 +26,14 @@ class SourceLocationTest extends TestCase
         $this->assertEquals('foobar', $location->getMessage());
         $this->assertEquals(['foo' => 'bar'], $location->getContext());
     }
+
+    public function testCreateHereViaCallback()
+    {
+        $location = array_map('\Translation\Extractor\Model\SourceLocation::createHere', ['baz'])[0];
+
+        $this->assertContains('tests/Unit/Model/SourceLocationTest.php', $location->getPath());
+        $this->assertEquals(32, $location->getLine());
+
+        $this->assertEquals('baz', $location->getMessage());
+    }
 }


### PR DESCRIPTION
Doing it via array_map would really help here in getting rid boilerplate code, when I already have list of strings as an array stored somewhere.

Without it, I need to do following each time:

```php
public static function getTranslationSourceLocations(): array
{
    $out = [];

    foreach(self::CHOICES as $choice) {
        $out[] = SourceLocation::createHere($choice);
    }

    return $out;
}
```


instead of 
```php
public static function getTranslationSourceLocations(): array
{
    return array_map('\Translation\Extractor\Model\SourceLocation::createHere', self::CHOICES);
}

```