### PR TITLE
Deal with help in symfony forms

### DIFF
--- a/src/Visitor/Php/Symfony/FormTrait.php
+++ b/src/Visitor/Php/Symfony/FormTrait.php
@@ -18,6 +18,8 @@ trait FormTrait
 {
     private $isFormType = false;
 
+    private $arrayNodeVisited = [];
+
     /**
      * Check if this node is a form type.
      *
@@ -33,5 +35,23 @@ trait FormTrait
         }
 
         return $this->isFormType;
+    }
+
+    /**
+     * Check if a node have been visited.
+     *
+     * @param Node $node
+     *
+     * @return bool
+     */
+    private function isKnownNode(Node $node)
+    {
+        $hash = spl_object_hash($node);
+        if (isset($this->arrayNodeVisited[$hash])) {
+            return true;
+        }
+        $this->arrayNodeVisited[$hash] = true;
+
+        return false;
     }
 }

--- a/src/Visitor/Php/Symfony/FormTypeHelp.php
+++ b/src/Visitor/Php/Symfony/FormTypeHelp.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Extractor\Visitor\Php\Symfony;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitor;
+
+final class FormTypeHelp extends AbstractFormType implements NodeVisitor
+{
+    use FormTrait;
+
+    public function enterNode(Node $node)
+    {
+        if (!$this->isFormType($node)) {
+            return;
+        }
+        parent::enterNode($node);
+
+        if (!$node instanceof Node\Expr\Array_) {
+            return;
+        }
+
+        $helpNode = null;
+        $domain = null;
+        foreach ($node->items as $item) {
+            if (!$item->key instanceof Node\Scalar\String_) {
+                continue;
+            }
+            if ('translation_domain' === $item->key->value) {
+                // Try to find translation domain
+                if ($item->value instanceof Node\Scalar\String_) {
+                    $domain = $item->value->value;
+                }
+            } elseif ('help' === $item->key->value) {
+                $helpNode = $item;
+            }
+        }
+
+        if (null === $helpNode) {
+            return;
+        }
+
+        if ($this->isKnownNode($helpNode)) {
+            return;
+        }
+
+        if ($helpNode->value instanceof Node\Scalar\String_) {
+            $line = $helpNode->value->getAttribute('startLine');
+            if (null !== $location = $this->getLocation($helpNode->value->value, $line, $helpNode, ['domain' => $domain])) {
+                $this->lateCollect($location);
+            }
+        } else {
+            $this->addError($helpNode, 'Form help is not a scalar string');
+        }
+    }
+}

--- a/src/Visitor/Php/Symfony/FormTypePlaceholder.php
+++ b/src/Visitor/Php/Symfony/FormTypePlaceholder.php
@@ -21,8 +21,6 @@ final class FormTypePlaceholder extends AbstractFormType implements NodeVisitor
 {
     use FormTrait;
 
-    private $arrayNodeVisited = [];
-
     public function enterNode(Node $node)
     {
         if (!$this->isFormType($node)) {
@@ -60,27 +58,24 @@ final class FormTypePlaceholder extends AbstractFormType implements NodeVisitor
             }
         }
 
-        if (null !== $placeholderNode) {
-            /**
-             * Make sure we do not visit the same placeholder node twice.
-             */
-            $hash = spl_object_hash($placeholderNode);
-            if (isset($this->arrayNodeVisited[$hash])) {
-                return;
-            }
-            $this->arrayNodeVisited[$hash] = true;
+        if (null === $placeholderNode) {
+            return;
+        }
 
-            if ($placeholderNode->value instanceof Node\Scalar\String_) {
-                $line = $placeholderNode->value->getAttribute('startLine');
-                if (null !== $location = $this->getLocation($placeholderNode->value->value, $line, $placeholderNode, ['domain' => $domain])) {
-                    $this->lateCollect($location);
-                }
-            } elseif ($placeholderNode->value instanceof Node\Expr\ConstFetch && 'false' === $placeholderNode->value->name->toString()) {
-                // 'placeholder' => false,
-                // Do noting
-            } else {
-                $this->addError($placeholderNode, 'Form placeholder is not a scalar string');
+        if ($this->isKnownNode($placeholderNode)) {
+            return;
+        }
+
+        if ($placeholderNode->value instanceof Node\Scalar\String_) {
+            $line = $placeholderNode->value->getAttribute('startLine');
+            if (null !== $location = $this->getLocation($placeholderNode->value->value, $line, $placeholderNode, ['domain' => $domain])) {
+                $this->lateCollect($location);
             }
+        } elseif ($placeholderNode->value instanceof Node\Expr\ConstFetch && 'false' === $placeholderNode->value->name->toString()) {
+            // 'placeholder' => false,
+            // Do noting
+        } else {
+            $this->addError($placeholderNode, 'Form placeholder is not a scalar string');
         }
     }
 }

--- a/tests/Functional/Visitor/Php/Symfony/FormTypeHelpTest.php
+++ b/tests/Functional/Visitor/Php/Symfony/FormTypeHelpTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the PHP Translation package.
+ *
+ * (c) PHP Translation team <tobias.nyholm@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Translation\Extractor\Tests\Functional\Visitor\Php\Symfony;
+
+use Translation\Extractor\Tests\Functional\Visitor\Php\BasePHPVisitorTest;
+use Translation\Extractor\Tests\Resources;
+use Translation\Extractor\Visitor\Php\Symfony\FormTypeHelp;
+use Translation\Extractor\Visitor\Php\Symfony\ContainerAwareTrans;
+
+final class FormTypeHelpTest extends BasePHPVisitorTest
+{
+    public function testExtract()
+    {
+        $collection = $this->getSourceLocations(new FormTypeHelp(),
+            Resources\Php\Symfony\HelpFormType::class);
+
+        $this->assertCount(2, $collection);
+        $this->assertEquals('form.help.text', $collection->get(0)->getMessage());
+        $this->assertEquals('form.help.text.but.no.label', $collection->get(1)->getMessage());
+    }
+
+    public function testExtractError()
+    {
+        $collection = $this->getSourceLocations(new FormTypeHelp(),
+            Resources\Php\Symfony\HelpFormErrorType::class);
+
+        $errors = $collection->getErrors();
+        $this->assertCount(2, $errors);
+    }
+
+    public function testChildVisitationNotBlocked()
+    {
+        $collection = $this->getSourceLocations(
+            [
+                new FormTypeHelp(),
+                new ContainerAwareTrans(),
+            ],
+            Resources\Php\Symfony\ContainerAwareTrans::class
+        );
+
+        $this->assertCount(6, $collection);
+
+        $this->assertEquals('trans0', $collection->get(0)->getMessage());
+        $this->assertEquals('trans1', $collection->get(1)->getMessage());
+        $this->assertEquals('trans_line', $collection->get(2)->getMessage());
+        $this->assertEquals('variable', $collection->get(3)->getMessage());
+        $this->assertEquals('my.pdf', $collection->get(4)->getMessage());
+        $this->assertEquals('bar', $collection->get(5)->getMessage());
+    }
+}

--- a/tests/Resources/Php/Symfony/HelpFormErrorType.php
+++ b/tests/Resources/Php/Symfony/HelpFormErrorType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Translation\Extractor\Tests\Resources\Php\Symfony;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Translation\Extractor\Annotation\Ignore;
+
+class PlaceholderFormErrorType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $string = 'foo';
+        $builder
+            ->add('field_with_help', 'text', array(
+                'label' => 'field.with.placeholder',
+                'help' => $string
+            ))
+            ->add('field_without_label_with_help', 'text', array(
+                'label' => false,
+                'help' => $string
+            ))
+        ;
+    }
+}

--- a/tests/Resources/Php/Symfony/HelpFormType.php
+++ b/tests/Resources/Php/Symfony/HelpFormType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Translation\Extractor\Tests\Resources\Php\Symfony;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class HelpFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('field_with_help', 'text', array(
+                'label' => 'field.with.help',
+                'help' => 'form.help.text'
+            ))
+            ->add('field_without_label_with_help', 'text', array(
+                'label' => false,
+                'help' => 'form.help.text.but.no.label'
+            ))
+        ;
+    }
+}


### PR DESCRIPTION
Add a new extractor to deal with the `help` attribue available [since sf4.1](https://symfony.com/blog/new-in-symfony-4-1-form-field-help).

Fix https://github.com/php-translation/symfony-bundle/issues/234