### PR TITLE
Do not run the Twig worker if we are not extracting,

### DIFF
--- a/src/Visitor/Twig/TwigVisitor.php
+++ b/src/Visitor/Twig/TwigVisitor.php
@@ -58,6 +58,12 @@ abstract class TwigVisitor extends BaseVisitor
      */
     protected function doEnterNode($node)
     {
+        // If not initialized
+        if (null === $this->collection) {
+            // We have not executed BaseVisitor::init which means that we are not currently extracting
+            return $node;
+        }
+
         return $this->worker->work($node, $this->collection, function () {
             return $this->getAbsoluteFilePath();
         });


### PR DESCRIPTION
The visitor will run at every time a new twig file is parsed. Since our visitors do not modify the Nodes we can safely ignore calls to `enterNode` if we not extracting. 

This will fix https://github.com/php-translation/symfony-bundle/issues/224