### PR TITLE
FormTypeChoices: @Ignore is ignored on choices

### DIFF
--- a/tests/Resources/Github/Issue_111.php
+++ b/tests/Resources/Github/Issue_111.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Translation\Extractor\Tests\Resources\Php\Symfony;
+
+use Translation\Extractor\Annotation\Ignore;
+
+class Issue111Type
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+
+        $builder
+            ->add('field_1', null, array(
+            /** @Ignore */
+            'choices' => array(
+                'github.issue_111.c' => 'c'
+            )
+        ));
+
+        $builder->add('field_2', null, array(
+            'choices' => array(
+                'github.issue_111.d' => 'd'
+            )
+        ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            /** @Ignore */
+            'choices' => function (Options $options) {
+                return array(
+                    'github.issue_111.a' => 'a',
+                    'github.issue_111.b' => 'b'
+                );
+            },
+            'foo_bar' => true
+        ));
+    }
+}

--- a/tests/Smoke/AllExtractorsTest.php
+++ b/tests/Smoke/AllExtractorsTest.php
@@ -76,6 +76,11 @@ class AllExtractorsTest extends TestCase
         $this->translationMissing($sc, 'github.issue_109.c');
         $this->translationExists($sc, 'github.issue_109.d');
 
+        $this->translationMissing($sc, 'github.issue_111.a');
+        $this->translationMissing($sc, 'github.issue_111.b');
+        $this->translationMissing($sc, 'github.issue_111.c');
+        $this->translationExists($sc, 'github.issue_111.d');
+
         /*
          * It is okey to increase the error count if you adding more fixtures/code.
          * We just need to be aware that it changes.


### PR DESCRIPTION
Hello,

`@ignore` annotation sound to be ignored on choices attribute

```php
$resolver->setDefaults([
      /** @Ignore */
      'choices' => function (Options $options) {
        return array(
          'a label' => 'a',
          'an other' => 'b'
        );
      }
    ]);
```
The visitor try to parse the function (and returns an error).

#112 