### PR TITLE
Prevent crash when getting callerName

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,12 @@ The change log describes what is "Added", "Removed", "Changed" or "Fixed" betwee
 
 ## UNRELEASED
 
+## 1.7.1
+
+### Fixed
+
+- Error when getting caller name with the `FlashMessage` extractor.
+
 ## 1.7.0
 
 ### Added

--- a/src/Visitor/Php/Symfony/FlashMessage.php
+++ b/src/Visitor/Php/Symfony/FlashMessage.php
@@ -35,6 +35,12 @@ final class FlashMessage extends BasePHPVisitor implements NodeVisitor
         }
 
         $name = (string) $node->name;
+
+        // This prevents dealing with some fatal edge cases when getting the callerName
+        if ('addFlash' !== $name && 'add' !== $name) {
+            return;
+        }
+
         $caller = $node->var;
         // $caller might be "Node\Expr\New_"
         $callerName = isset($caller->name) ? (string) $caller->name : '';

--- a/src/Visitor/Php/Symfony/FlashMessage.php
+++ b/src/Visitor/Php/Symfony/FlashMessage.php
@@ -37,7 +37,7 @@ final class FlashMessage extends BasePHPVisitor implements NodeVisitor
         $name = (string) $node->name;
 
         // This prevents dealing with some fatal edge cases when getting the callerName
-        if ('addFlash' !== $name && 'add' !== $name) {
+        if (!in_array($name, ['addFlash', 'add'])) {
             return;
         }
 


### PR DESCRIPTION
Hey,

I experienced crash in my symfony project when extacting keys. Here is a quick fix that prevents dealing with edge cases. 

Cheers,
Marc