### PR TITLE
fixed FormTypeLabelImplicit visitor when constant is used as option key #131

### DIFF
--- a/src/Visitor/Php/Symfony/FormTypeLabelImplicit.php
+++ b/src/Visitor/Php/Symfony/FormTypeLabelImplicit.php
@@ -49,11 +49,11 @@ final class FormTypeLabelImplicit extends AbstractFormType implements NodeVisito
             if (count($node->args) >= 3) {
                 if ($node->args[2]->value instanceof Node\Expr\Array_) {
                     foreach ($node->args[2]->value->items as $item) {
-                        if (isset($item->key) && 'label' === $item->key->value) {
+                        if (isset($item->key) && $item->key instanceof Node\Scalar\String_ && 'label' === $item->key->value) {
                             $skipLabel = true;
                         }
 
-                        if (isset($item->key) && 'translation_domain' === $item->key->value) {
+                        if (isset($item->key) && $item->key instanceof Node\Scalar\String_ && 'translation_domain' === $item->key->value) {
                             if ($item->value instanceof Node\Scalar\String_) {
                                 $domain = $item->value->value;
                             } elseif ($item->value instanceof Node\Expr\ConstFetch && 'false' === $item->value->name->toString()) {

--- a/tests/Functional/Visitor/Php/Symfony/FormTypeLabelImplicitTest.php
+++ b/tests/Functional/Visitor/Php/Symfony/FormTypeLabelImplicitTest.php
@@ -24,7 +24,7 @@ class FormTypeLabelImplicitTest extends BasePHPVisitorTest
     {
         $collection = $this->getSourceLocations(new FormTypeLabelImplicit(), Resources\Php\Symfony\ImplicitLabelType::class);
 
-        $this->assertCount(4, $collection, print_r($collection, true));
+        $this->assertCount(5, $collection, print_r($collection, true));
         $this->assertEquals('find1', $collection->get(0)->getMessage());
         $this->assertEquals('bigger_find2', $collection->get(1)->getMessage());
         $this->assertEquals('camelFind3', $collection->get(2)->getMessage());

--- a/tests/Resources/Php/Symfony/ImplicitLabelType.php
+++ b/tests/Resources/Php/Symfony/ImplicitLabelType.php
@@ -4,6 +4,8 @@ namespace Translation\Extractor\Tests\Resources\Php\Symfony;
 
 class ImplicitLabelType
 {
+    const ISSUE_131 = 'issue_131';
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $var = 'test';
@@ -15,10 +17,13 @@ class ImplicitLabelType
         $builder->add(function () { return 'skip3'; });
         // Symfony will throw an error I guess, but at least extractions skip it
         $builder->add('');
-		
+
 		//issue87: support for Ignore annotation
 		$generateOptions = function() { return ['label' => false]; };
         $builder->add('issue87-willBeAdded', null, $generateOptions);
         $builder->add(/** @Ignore */'issue87-shouldNotBeAdded', null, $generateOptions);
+
+        //issue131: support for constant as option key
+        $builder->add('issue_131', null, [self::ISSUE_131 => true]);
     }
 }


### PR DESCRIPTION
This PR will fix #131 where the extractor crashes when constant are used as options keys 
