### PR TITLE
Call to trans with variable must not trigger Exception

### DIFF
--- a/src/Visitor/Php/Symfony/ContainerAwareTrans.php
+++ b/src/Visitor/Php/Symfony/ContainerAwareTrans.php
@@ -45,6 +45,9 @@ final class ContainerAwareTrans extends BasePHPVisitor implements NodeVisitor
         //If $this->get('translator')->trans('foobar')
         if ('trans' === $name) {
             $label = $this->getStringArgument($node, 0);
+            if (null === $label) {
+                return null;
+            }
             $domain = $this->getStringArgument($node, 2);
 
             $this->addLocation($label, $node->getAttribute('startLine'), $node, ['domain' => $domain]);

--- a/tests/Resources/Php/Symfony/ContainerAwareTrans.php
+++ b/tests/Resources/Php/Symfony/ContainerAwareTrans.php
@@ -55,4 +55,12 @@ class ContainerAwareTrans
     {
         $translator = static::$container->get('translator'); $foo = $translator->trans('bar');
     }
+
+    public function transWithVariable()
+    {
+        $key = 'trans_key';
+
+        // This should not be source Locations
+        return $this->translator->trans($key);
+    }
 }


### PR DESCRIPTION
9070899a20694f875b33fc27c2cdfb20fe419c3b introduced strict string on BaseVisitor addLocation method, calls to trans($myVar) should not be added.