### PR TITLE
refac: add return type to fix deprecation

### DIFF
--- a/src/Visitor/Twig/TwigVisitor.php
+++ b/src/Visitor/Twig/TwigVisitor.php
@@ -59,7 +59,7 @@ final class TwigVisitor extends BaseVisitor implements NodeVisitorInterface
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 0;
     }


### PR DESCRIPTION
Fix deprecation message in symfony 5.4
```
Method "Twig\NodeVisitor\NodeVisitorInterface::getPriority()" might add "int" as a native return type declaration in the future. Do the same in implementation "Translation\Extractor\Visitor\Twig\TwigVisitor" now to avoid errors or add an explicit @return annotation to suppress this message.
```