### PR TITLE
Simplify badges list and other minor README tweaks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,10 +1,6 @@
 # Translation extractor
 
 [![Latest Version](https://img.shields.io/github/release/php-translation/extractor.svg?style=flat-square)](https://github.com/php-translation/extractor/releases)
-[![Build Status](https://travis-ci.org/php-translation/extractor.svg?branch=master)](http://travis-ci.org/php-translation/extractor)
-[![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/php-translation/extractor.svg?style=flat-square)](https://scrutinizer-ci.com/g/php-translation/extractor)
-[![Quality Score](https://img.shields.io/scrutinizer/g/php-translation/extractor.svg?style=flat-square)](https://scrutinizer-ci.com/g/php-translation/extractor)
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/a5ae0cbe-f213-4ba6-94da-e9cffed86256/mini.png)](https://insight.sensiolabs.com/projects/a5ae0cbe-f213-4ba6-94da-e9cffed86256)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-translation/extractor.svg?style=flat-square)](https://packagist.org/packages/php-translation/extractor)
 
 **Extract translation messages from source code**
@@ -12,9 +8,9 @@
 
 ## Install
 
-Via Composer
+Via Composer:
 
-``` bash
+```bash
 $ composer require php-translation/extractor
 ```
 
@@ -23,7 +19,7 @@ $ composer require php-translation/extractor
 ```php
 $extractor = new Extractor();
 
-// Create extractor for PHP files
+// Create an extractor for PHP files
 $fileExtractor = new PHPFileExtractor();
 
 // Add visitors
@@ -45,13 +41,11 @@ $sourceCollection = $extractor->extract($finder);
 
 ## Found an issue?
 
-Is it something we do not extract? Please add it as a tests. Add a new file with your example code in
-`tests/Resources/Github/Issue_XX.php` then edit the `AllExtractorsTest` to make sure the translation
-key is found. 
+Is it something we do not extract? Please add it as a test. Add a new file with your example code in
+`tests/Resources/Github/Issue_XX.php`, then edit the `AllExtractorsTest` to make sure the translation
+key is found:
 
 ```php
-
 // ...
 $this->translationExists($sc, 'trans.issue_xx');
-
 ```


### PR DESCRIPTION
- Travis CI was dropped in favor of GitHub Actions and does not work anymore
- Scrutinizer does not work anymore, the last build was 2 years ago
- SensioLabsInsight was migrated to SymfonyInsight, but there's no this project, it returns 404
