### PR TITLE
Use host PHP version instead of hardcoded version to parse newer syntax

### DIFF
--- a/src/FileExtractor/PHPFileExtractor.php
+++ b/src/FileExtractor/PHPFileExtractor.php
@@ -15,7 +15,6 @@ use PhpParser\Error;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use PhpParser\ParserFactory;
-use PhpParser\PhpVersion;
 use Symfony\Component\Finder\SplFileInfo;
 use Translation\Extractor\Model\SourceCollection;
 use Translation\Extractor\Visitor\Visitor;
@@ -33,8 +32,7 @@ final class PHPFileExtractor implements FileExtractor
     public function getSourceLocations(SplFileInfo $file, SourceCollection $collection): void
     {
         $path = $file->getRelativePath();
-        /** @phpstan-ignore-next-line */
-        $parser = (new ParserFactory())->createForVersion(PhpVersion::fromString('8.1'));
+        $parser = (new ParserFactory())->createForHostVersion();
         $traverser = new NodeTraverser();
         $traverser->addVisitor(new NodeVisitor\NameResolver());
         foreach ($this->visitors as $v) {

--- a/src/Visitor/Php/Symfony/FormTrait.php
+++ b/src/Visitor/Php/Symfony/FormTrait.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\ParserFactory;
-use PhpParser\PhpVersion;
 
 trait FormTrait
 {
@@ -80,7 +79,7 @@ trait FormTrait
             }
 
             /** @phpstan-ignore-next-line */
-            $parser = (new ParserFactory())->createForVersion(PhpVersion::fromString('8.1'));
+            $parser = (new ParserFactory())->createForHostVersion();
             $code = file_get_contents($filePath);
             $stmts = $parser->parse($code);
 


### PR DESCRIPTION
Closes #188.

Since the app code is being run with a certain host php version, we should support parsing with that exact version.