### PR TITLE
Allow FormTypeExtensionInterface to be visited like FormTypeInterface

### DIFF
--- a/src/Visitor/Php/Symfony/FormTrait.php
+++ b/src/Visitor/Php/Symfony/FormTrait.php
@@ -21,7 +21,7 @@ trait FormTrait
 {
     private bool $isFormType = false;
     private array $classMap = [];
-    private string $symfonyInterface = 'FormTypeInterface';
+    private array $symfonyInterfaces = ['FormTypeInterface', 'FormTypeExtensionInterface'];
 
     protected function isFormType(Node $node): bool
     {
@@ -32,9 +32,11 @@ trait FormTrait
         $allInterfaces = $this->getAllInterfacesFromNode($node);
 
         foreach ($allInterfaces as $interface) {
-            if ($interface === $this->symfonyInterface
-                || str_ends_with($interface, '\\'.$this->symfonyInterface)) {
-                $this->isFormType = true;
+            foreach ($this->symfonyInterfaces as $symfonyInterface) {
+                if ($interface === $symfonyInterface || str_ends_with($interface, '\\'.$symfonyInterface)) {
+                    $this->isFormType = true;
+                    break;
+                }
             }
         }
 

--- a/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
+++ b/tests/Functional/Visitor/Php/Symfony/FormTypeChoicesTest.php
@@ -53,6 +53,17 @@ class FormTypeChoicesTest extends BasePHPVisitorTest
         $this->assertEquals('label2', $collection->get(1)->getMessage());
     }
 
+    public function testChainedChoiceExtension(): void
+    {
+        $visitor = new FormTypeChoices();
+        $visitor->setSymfonyMajorVersion(3);
+        $collection = $this->getSourceLocations($visitor, ChainedChoicedTypeExtension::class);
+
+        $this->assertCount(2, $collection, print_r($collection, true));
+        $this->assertEquals('label1', $collection->get(0)->getMessage());
+        $this->assertEquals('label2', $collection->get(1)->getMessage());
+    }
+
     public function testExtractError(): void
     {
         $collection = $this->getSourceLocations(new FormTypeChoices(), SimpleChoiceSymfony3xErrorType::class);

--- a/tests/Resources/Php/Symfony/ChainedChoiceType.php
+++ b/tests/Resources/Php/Symfony/ChainedChoiceType.php
@@ -2,9 +2,12 @@
 
 namespace Translation\Extractor\Tests\Resources\Php\Symfony;
 
-class ChainedChoiceType implements FormTypeInterface
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ChainedChoiceType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('name')

--- a/tests/Resources/Php/Symfony/ChainedChoicedTypeExtension.php
+++ b/tests/Resources/Php/Symfony/ChainedChoicedTypeExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Translation\Extractor\Tests\Resources\Php\Symfony;
+
+class ChainedChoicedTypeExtension implements FormTypeExtensionInterface
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name')
+            ->add('test', null, [
+                'choices' => [
+                    'label1' => 'key',
+                    'label2' => 'key',
+                ],
+            ]);
+    }
+}

--- a/tests/Resources/Php/Symfony/ChainedChoicedTypeExtension.php
+++ b/tests/Resources/Php/Symfony/ChainedChoicedTypeExtension.php
@@ -2,8 +2,18 @@
 
 namespace Translation\Extractor\Tests\Resources\Php\Symfony;
 
-class ChainedChoicedTypeExtension implements FormTypeExtensionInterface
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class ChainedChoicedTypeExtension extends AbstractTypeExtension
 {
+    public static function getExtendedTypes(): iterable
+    {
+        return [
+            ChainedChoiceType::class,
+        ];
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder


### PR DESCRIPTION
closes #191 
Allow classes implementing FormTypeExtensionInterface to be visited the same way that classesd implementing FormTypeInterface.

I've added a very basic tests and an early break in the loop.
When the lib is php >= 8.4 we can use array_find instead